### PR TITLE
Add PORTABLE option to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,13 @@ include_directories(${CASACORE_INCLUDE_DIRS})
 include_directories(${Boost_INCLUDE_DIR})
 include_directories(${GSL_INCLUDE_DIR})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -DNDEBUG -march=native --std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -DNDEBUG --std=c++11")
+
+if(PORTABLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native") 
+endif(PORTABLE)
 
 add_library(dyscostman-object OBJECT
 	aftimeblockencoder.cpp


### PR DESCRIPTION
I have been bitten again by the native architecture in my heterogeneous cluster. This PR adds the PORTABLE option to disable the native compiler flag in CMake.