### PR TITLE
[Draft] Disabling threading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native") 
 endif(PORTABLE)
 
+if(ENABLE_THREADS)
+	add_definitions(-DENABLE_THREADS)
+endif(ENABLE_THREADS)
+
 add_library(dyscostman-object OBJECT
 	aftimeblockencoder.cpp
 	dyscostman.cpp

--- a/dyscodatacolumn.h
+++ b/dyscodatacolumn.h
@@ -62,6 +62,7 @@ protected:
 	virtual size_t symbolCount(size_t nRowsInBlock, size_t nPolarizations, size_t nChannels) const final override;
 	
 	virtual size_t defaultThreadCount() const final override;
+	
 private:
 	struct ThreadData
 	{


### PR DESCRIPTION
By default, Dysco uses multi-threading and caching for compressing the data. Decompressing is serial.

This behaviour has caused problems when writing to measurement sets itself is also parallelized, for example by running many DP3 instances at the same time. At that point, this was solved by reducing the maximum nr of threads to 8 (instead of to the nr of CPU cores). Recently, @adrabent reported more issues when running aoflagger on a spw combined set. These issues, together with that I'm not sure how much the multi-threading really improves in common cases, gave rise to developing a branch in which threading is disabled.

This is quite a big change, and due to the implications to production data quality associated with Dysco, I'll keep this thread open for a while, for testing, before merging it.