### PR TITLE
Add CMake options to use AVX/FMA extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,30 +23,36 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(BUILD_PACKAGES "Build Debian packages" OFF)
 option(PORTABLE "Build portable binaries (with slightly decreased performance)"
        OFF)
-option(USE_AVX512F "Enable AVX-512F (AVX-512 Foundation) Extensions" OFF)
 option(USE_AVX2 "Enable AVX2 (Advanced Vector Extensions 2)" OFF)
-option(USE_AVX "Enable AVX (Advanced Vector Extensions)" OFF)
+option(USE_AVX512F "Enable AVX-512F (AVX-512 Foundation) Extensions" OFF)
+option(USE_FMA "Enable FMA (Fused Multiply Add) - implies use of AVX" OFF)
 
 if(PORTABLE)
-  if(USE_AVX512F
-     OR USE_AVX2
-     OR USE_AVX)
+  if(USE_AVX2
+     OR USE_AVX512F
+     OR USE_FMA)
     message(
-      FATAL_ERROR "Cannot enable AVX features when building portable binaries.")
+      FATAL_ERROR
+        "Cannot enable AVX/FMA features when building portable binaries.")
   endif()
   message(
     STATUS
       "Portable build requested; a generic build will be created with slightly decreased performance."
   )
 else()
-  if(USE_AVX512F)
-    add_compile_options(-mavx512f)
-  elseif(USE_AVX2)
-    add_compile_options(-mavx2)
-  elseif(USE_AVX)
-    add_compile_options(-mavx)
-  else()
+  if(NOT USE_AVX2
+     AND NOT USE_AVX512F
+     AND NOT USE_FMA)
     add_compile_options(-march=native)
+  else()
+    if(USE_AVX512F)
+      add_compile_options(-mavx512f)
+    elseif(USE_AVX2)
+      add_compile_options(-mavx2)
+    endif()
+    if(USE_FMA)
+      add_compile_options(-mfma)
+    endif()
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,25 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-option(PORTABLE "Generate portable code" OFF)
 option(BUILD_PACKAGES "Build Debian packages" OFF)
+option(PORTABLE "Build portable binaries (with slightly decreased performance)"
+       OFF)
+option(USE_AVX512F "Enable AVX-512F (AVX-512 Foundation) Extensions" OFF)
+option(USE_AVX2 "Enable AVX2 (Advanced Vector Extensions 2)" OFF)
+option(USE_AVX "Enable AVX (Advanced Vector Extensions)" OFF)
 
-if(NOT PORTABLE)
+if(PORTABLE)
+  if(USE_AVX512F
+     OR USE_AVX2
+     OR USE_AVX)
+    message(
+      FATAL_ERROR "Cannot enable AVX features when building portable binaries.")
+  endif()
+  message(
+    STATUS
+      "Portable build requested; a generic build will be created with slightly decreased performance."
+  )
+else()
   if(USE_AVX512F)
     add_compile_options(-mavx512f)
   elseif(USE_AVX2)
@@ -32,13 +47,6 @@ if(NOT PORTABLE)
     add_compile_options(-mavx)
   else()
     add_compile_options(-march=native)
-  endif()
-else()
-  if(USE_AVX512F
-     OR USE_AVX2
-     OR USE_AVX)
-    message(
-      FATAL_ERROR "Cannot enable AVX features when building portable code.")
   endif()
 endif()
 


### PR DESCRIPTION
This PR adds CMake options to enable AVX and FMA compile optimizations. The `PORTABLE` option remains and its meaning doesn't change. In other words, if `PORTABLE=OFF` and none of the new CMake options are enabled (they are disabled by default), then a native (optimized) build will be done. If any of the new option are enabled, then these options supersede the `-march=native` option. If `PORTABLE=ON`, enabling any of the new AVX/FMA options will generate an error.