### PR TITLE
Add possibility to set target CPU architecture

### DIFF
--- a/CMake/SetTargetCPU.cmake
+++ b/CMake/SetTargetCPU.cmake
@@ -7,7 +7,13 @@
 
 include(CheckCXXCompilerFlag)
 if(PORTABLE)
-  if(DEFINED TARGET_CPU)
+  # Empty by default, will be overridden when given on the command-line
+  set(TARGET_CPU
+      CACHE
+        STRING
+        "Tell the compiler to build code for the given CPU, e.g. for building containers for a different platform"
+  )
+  if(TARGET_CPU)
     message(
       FATAL_ERROR
         "You cannot specify a target CPU when building portable binaries. "
@@ -15,14 +21,19 @@ if(PORTABLE)
   endif()
   message(
     WARNING
-      "Building portable binaries, which will have slightly decreased performance."
+      "Building portable binaries, which will have slighly decreased performance."
   )
 else()
-  if(NOT DEFINED TARGET_CPU)
-    set(TARGET_CPU native)
+  if(NOT TARGET_CPU)
+    # If not set, force it to use native CPU by default
+    set(TARGET_CPU
+        native
+        CACHE
+          STRING
+          "Tell the compiler to build code for the given CPU, e.g. for building containers for a different platform"
+          FORCE)
   endif()
-  # Unset cached variable to force a check; the user may have given a different
-  # value for TARGET_CPU.
+  # Unset cached variable to force a check; value of TARGET_CPU may have changed
   unset(COMPILER_SUPPORTS_TARGET_CPU CACHE)
   check_cxx_compiler_flag("-march=${TARGET_CPU}" COMPILER_SUPPORTS_TARGET_CPU)
   if(COMPILER_SUPPORTS_TARGET_CPU)

--- a/CMake/SetTargetCPU.cmake
+++ b/CMake/SetTargetCPU.cmake
@@ -1,0 +1,36 @@
+# Instruct the compiler to generate portable binaries if `PORTABLE=ON`.
+# If `PORTABLE=OFF`, instruct the compiler to generate binaries that are optimized
+# for the native CPU. The user may override this by setting `TARGET_CPU` to a
+# specifc CPU architecture, e.g. `TARGET_CPU=haswell`. If the compiler doesn't know
+# how to generate code for the given `TARGET_CPU`, an error will be raised.
+# You cannot set `TARGET_CPU` if `PORTABLE=ON`.
+
+include(CheckCXXCompilerFlag)
+if(PORTABLE)
+  if(DEFINED TARGET_CPU)
+    message(
+      FATAL_ERROR
+        "You cannot specify a target CPU when building portable binaries. "
+        "Set PORTABLE=OFF if you want to set TARGET_CPU.")
+  endif()
+  message(
+    WARNING
+      "Building portable binaries, which will have slighly decreased performance."
+  )
+else()
+  if(NOT DEFINED TARGET_CPU)
+    set(TARGET_CPU native)
+  endif()
+  # Unset cached variable to force a check; the user may have given a different
+  # value for TARGET_CPU.
+  unset(COMPILER_SUPPORTS_TARGET_CPU CACHE)
+  check_cxx_compiler_flag("-march=${TARGET_CPU}" COMPILER_SUPPORTS_TARGET_CPU)
+  if(COMPILER_SUPPORTS_TARGET_CPU)
+    add_compile_options(-march=${TARGET_CPU})
+  else()
+    message(
+      FATAL_ERROR
+        "The compiler doesn't support '${TARGET_CPU}' as target CPU architecture."
+    )
+  endif()
+endif(PORTABLE)

--- a/CMake/SetTargetCPU.cmake
+++ b/CMake/SetTargetCPU.cmake
@@ -21,7 +21,7 @@ if(PORTABLE)
   endif()
   message(
     WARNING
-      "Building portable binaries, which will have slighly decreased performance."
+      "Building portable binaries, which will have slightly decreased performance."
   )
 else()
   if(NOT TARGET_CPU)

--- a/CMake/SetTargetCPU.cmake
+++ b/CMake/SetTargetCPU.cmake
@@ -15,7 +15,7 @@ if(PORTABLE)
   endif()
   message(
     WARNING
-      "Building portable binaries, which will have slighly decreased performance."
+      "Building portable binaries, which will have slightly decreased performance."
   )
 else()
   if(NOT DEFINED TARGET_CPU)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,27 +20,10 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-option(PORTABLE "Generate portable code" OFF)
 option(BUILD_PACKAGES "Build Debian packages" OFF)
-
-if(NOT PORTABLE)
-  if(USE_AVX512F)
-    add_compile_options(-mavx512f)
-  elseif(USE_AVX2)
-    add_compile_options(-mavx2)
-  elseif(USE_AVX)
-    add_compile_options(-mavx)
-  else()
-    add_compile_options(-march=native)
-  endif()
-else()
-  if(USE_AVX512F
-     OR USE_AVX2
-     OR USE_AVX)
-    message(
-      FATAL_ERROR "Cannot enable AVX features when building portable code.")
-  endif()
-endif()
+option(PORTABLE "Build portable binaries (with slightly decreased performance)"
+       OFF)
+include(CMake/SetTargetCPU.cmake)
 
 add_library(
   dyscostman-object OBJECT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(BUILD_PACKAGES "Build Debian packages" OFF)
+
+# User may optionally set `TARGET_CPU` if `PORTABLE=OFF`
 option(PORTABLE "Build portable binaries (with slightly decreased performance)"
        OFF)
 include(CMake/SetTargetCPU.cmake)


### PR DESCRIPTION
This PR adds the possibility to specify for which CPU architecture the compiler should build binaries. It replaces the existing method where one or more AVX extensions could be enabled by setting the associated variables. The rationale is that it makes more sense to optimize for a certain CPU micro-architecture (and its successors) than to only enable specific AVX features.

The `PORTABLE` option is retained and its behavior doesn't change. I.e., setting `PORTABLE=ON` will instruct the compiler to build binaries that can be run on any X86-64 CPU; setting `PORTABLE=OFF` will instruct the compiler to use the native CPU as target. The user can instruct the compiler to target a specific CPU by setting the CMake variable `TARGET_CPU`. Setting `TARGET_CPU` if `PORTABLE=ON` will raise an error. Setting `TARGET_CPU` to a CPU type the compiler doesn't support will also raise an error.